### PR TITLE
Add donorbox link to nav.

### DIFF
--- a/content/navItems.ts
+++ b/content/navItems.ts
@@ -21,7 +21,7 @@ const navItems: navItem[] = [
     text: "Why Vacate",
   },
   {
-    href: "donate",
+    href: "https://donorbox.org/clearviction",
     text: "Donate",
   },
   {


### PR DESCRIPTION
In lieu of a donation page, I have added the link to our donorbox page. This can be considered a stop-gap.