### PR TITLE
Fix: bug 253

### DIFF
--- a/pages/get-started.tsx
+++ b/pages/get-started.tsx
@@ -73,7 +73,7 @@ export default function GetStartedPage() {
           title="Step 2: Eligibility"
           bodyText={`Once you have your records and forms gathered, use our eligibilty calculator to determine whether you are eligible to vacate your misdemeanor conviction. It is expected to take 10-30 minutes.`}
           ctaText="Access Calculator"
-          ctaLink='"/calculator/head-initial-1-cont"'
+          ctaLink="/calculator/head-initial-1-cont"
         >
           <SectionContainer>
             <Grid container sx={{ alignItems: "center" }}>


### PR DESCRIPTION
This fixes [Bug 253](https://airtable.com/appfJZShN8K4tcWHU/tblvBIYoi6TLmdRAv/viwtS9qwzRGDF3VVl/recWGQjwjmbOBDmf2?blocks=hide). The use of a double set of quotes when defining the ctaLink was causing users to get a 404 error page instead of the calculator landing page. I removed the outer set of quotes and it cleared the error.