### PR TITLE
Why vacate spacing

### DIFF
--- a/components/GridItem.tsx
+++ b/components/GridItem.tsx
@@ -13,7 +13,7 @@ export function GridItemCard({
   ...props
 }: GridItemCardProps) {
   return (
-    <Grid item {...props} sx={{ mb: 4, justifyContent: 'center' }}>
+    <Grid item {...props} sx={{ mb: 4, justifyContent: "center" }}>
       <Box textAlign="center">
         {imgsrc && (
           <Box
@@ -28,35 +28,39 @@ export function GridItemCard({
             }}
           ></Box>
         )}
-        <Typography variant="subtitle2" 
-          sx={{ 
-            fontWeight: 'bold', 
-            marginBottom: '10px', 
-            maxWidth: '250px', 
-            margin: '27px auto auto',
-            minHeight: '62px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }} >
-            {title}
-          </Typography>
+        <Typography
+          variant="subtitle2"
+          sx={{
+            fontWeight: "bold",
+            marginBottom: "10px",
+            maxWidth: "250px",
+            margin: "27px auto auto",
+            minHeight: "62px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          {title}
+        </Typography>
         <Box textAlign="left">
-          <MuiMarkdown 
+          <MuiMarkdown
             overrides={{
               span: {
-                component: 'p',
+                component: "p",
                 props: {
-                  style: { 
-                    maxWidth: '260px',
-                    display: 'flex',
-                    margin: '20px auto',
-                    textAlign: 'center',
+                  style: {
+                    maxWidth: "260px",
+                    display: "flex",
+                    margin: "20px auto",
+                    textAlign: "center",
                   },
                 } as React.HTMLProps<HTMLParagraphElement>,
               },
             }}
-          >{body}</MuiMarkdown>
+          >
+            {body}
+          </MuiMarkdown>
         </Box>
       </Box>
     </Grid>

--- a/components/GridItem.tsx
+++ b/components/GridItem.tsx
@@ -13,7 +13,7 @@ export function GridItemCard({
   ...props
 }: GridItemCardProps) {
   return (
-    <Grid item {...props} sx={{ mb: 4 }}>
+    <Grid item {...props} sx={{ mb: 4, justifyContent: 'center' }}>
       <Box textAlign="center">
         {imgsrc && (
           <Box
@@ -28,9 +28,35 @@ export function GridItemCard({
             }}
           ></Box>
         )}
-        <Typography variant="subtitle1">{title}</Typography>
+        <Typography variant="subtitle2" 
+          sx={{ 
+            fontWeight: 'bold', 
+            marginBottom: '10px', 
+            maxWidth: '250px', 
+            margin: '27px auto auto',
+            minHeight: '62px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }} >
+            {title}
+          </Typography>
         <Box textAlign="left">
-          <MuiMarkdown>{body}</MuiMarkdown>
+          <MuiMarkdown 
+            overrides={{
+              span: {
+                component: 'p',
+                props: {
+                  style: { 
+                    maxWidth: '260px',
+                    display: 'flex',
+                    margin: '20px auto',
+                    textAlign: 'center',
+                  },
+                } as React.HTMLProps<HTMLParagraphElement>,
+              },
+            }}
+          >{body}</MuiMarkdown>
         </Box>
       </Box>
     </Grid>


### PR DESCRIPTION
When small cards were changed into one large card, the spacing needed to be updated, and bold the titles of the cards

![Screenshot 2023-03-18 at 5 29 32 PM](https://user-images.githubusercontent.com/59981297/226143557-687673fe-3744-46fb-b9bc-c554b106e0f0.png)
![Screenshot 2023-03-18 at 5 30 33 PM](https://user-images.githubusercontent.com/59981297/226143573-1306aad3-9e35-44f1-be35-4d2031922f2a.png)
![Screenshot 2023-03-18 at 5 30 41 PM](https://user-images.githubusercontent.com/59981297/226143574-c1a5b87b-4cc7-44f0-92e5-787aad94a835.png)
![Screenshot 2023-03-18 at 5 29 15 PM](https://user-images.githubusercontent.com/59981297/226143618-74186453-f4bd-4700-b91b-c5f5e37b1f50.png)
